### PR TITLE
Process translations

### DIFF
--- a/data-translate.csv
+++ b/data-translate.csv
@@ -1,0 +1,4 @@
+druid,media_filename,media_language,transcript_filename,transcript_language
+qf378nj5000,bags/qf378nj5000/data/content/qf378nj5000_sl.mp4,es,bags/qf378nj5000/data/content/qf378nj5000_script.txt,en
+br525sp8033,bags/br525sp8033/data/content/br525sp8033_FV4289_v4_sl.mp4,ru,bags/br525sp8033/data/content/br525sp8033_FV4289_eng_cap.vtt,en
+br525sp8033,bags/br525sp8033/data/content/br525sp8033_FV4289_v4_sl.mp4,ru,bags/br525sp8033/data/content/br525sp8033_FV4289_rus_cap.vtt,ru

--- a/data.csv
+++ b/data.csv
@@ -8,5 +8,5 @@ gj097zq7635,bags/gj097zq7635/data/content/gj097zq7635_a_sl.m4a,en,bags/gj097zq76
 gk220dt2833,bags/gk220dt2833/data/content/gk220dt2833_Ali_Shan_10of10_sl.mp4,en,bags/gk220dt2833/data/content/gk220dt2833_Ali_Shan_10of10_sl_script.txt,en
 gn213vd3845,bags/gn213vd3845/data/content/gn213vd3845_ev_1_sl.mp4,es,bags/gn213vd3845/data/content/gn213vd3845_ev_1_sl_spa_script.txt,es
 kp010zv7055,bags/kp010zv7055/data/content/kp010zv7055_a_sl.m4a,en,bags/kp010zv7055/data/content/kp010zv7055_a_sl_script.txt,en
-qf378nj5000,bags/qf378nj5000/data/content/qf378nj5000_sl.mp4,en,bags/qf378nj5000/data/content/qf378nj5000_script.txt,en
+qf378nj5000,bags/qf378nj5000/data/content/qf378nj5000_sl.mp4,en,bags/qf378nj5000/data/content/qf378nj5000_script.txt,es
 tc482fh1865,bags/tc482fh1865/data/content/tc482fh1865_kfe_project_2023_wallace_sl.mp4,en,bags/tc482fh1865/data/content/tc482fh1865_kfe_project_2023_wallace_script.txt,en

--- a/test/test_whisper.py
+++ b/test/test_whisper.py
@@ -33,7 +33,11 @@ def test_get_language_with_silence():
 
 def test_transcribe():
     t = whisper.transcribe(
-        {"media_filename": path.join(TEST_DATA, "en.wav"), "media_language": "en"},
+        {
+            "media_filename": path.join(TEST_DATA, "en.wav"),
+            "media_language": "en",
+            "transcript_language": "en",
+        },
         {"model_name": MODEL_SIZE},
     )
 
@@ -43,12 +47,32 @@ def test_transcribe():
 
 def test_transcribe_fr():
     t = whisper.transcribe(
-        {"media_filename": path.join(TEST_DATA, "fr.wav"), "media_language": "fr"},
+        {
+            "media_filename": path.join(TEST_DATA, "fr.wav"),
+            "media_language": "fr",
+            "transcript_language": "fr",
+        },
         {"model_name": MODEL_SIZE},
     )
     assert (
         t["segments"][0]["text"]
         == " Il s'agit d'un test de lecture de whisper en français."
+    )
+    assert t["language"] == "fr"
+
+
+def test_translate():
+    t = whisper.transcribe(
+        {
+            "media_filename": path.join(TEST_DATA, "fr.wav"),
+            "media_language": "fr",
+            "transcript_language": "en",
+        },
+        {"model_name": MODEL_SIZE},
+    )
+    assert (
+        t["segments"][0]["text"]
+        == " It's a test of the newspaper of Whisper in French."
     )
     assert t["language"] == "fr"
 

--- a/transcribe/whisper.py
+++ b/transcribe/whisper.py
@@ -137,6 +137,14 @@ def transcribe(file_metadata, options):
     whisper_options = options.copy()
     whisper_options.pop("model_name")
 
+    # if the languages of the source media and transcript are different and the
+    # transcript is to be in English then we tell Whisper to translate
+    if (
+        file_metadata["media_language"] != file_metadata["transcript_language"]
+        and file_metadata["transcript_language"] == "en"
+    ):
+        whisper_options["task"] = "translate"
+
     whisper_options["language"] = file_metadata["media_language"]
     audio = load_audio(file_metadata["media_filename"])
 


### PR DESCRIPTION
When the source language is different from the transcript language in
the data.csv, and the transcript language is `en` then run whisper in
translate mode instead of transcribe.

Fixes #14
